### PR TITLE
Updated flags for compressed keys

### DIFF
--- a/contracthashtool.c
+++ b/contracthashtool.c
@@ -251,7 +251,7 @@ int main(int argc, char* argv[]) {
 					break; // if tweak > order
 				}
 				size_t len = 33;
-				secp256k1_ec_pubkey_serialize(secp256k1_ctx, keys_work[i], &len, &pubkey, 1);
+				secp256k1_ec_pubkey_serialize(secp256k1_ctx, keys_work[i], &len, &pubkey, SECP256K1_EC_COMPRESSED);
 				assert(len == 33);
 			}
 			if (i == key_count)
@@ -295,7 +295,7 @@ int main(int argc, char* argv[]) {
 		size_t len = 0;
 		if (secp256k1_ec_pubkey_create(secp256k1_ctx, &pubkey, priv) != 1)
 			ERROREXIT("Private key was invalid\n");
-		secp256k1_ec_pubkey_serialize(secp256k1_ctx, pub, &len, &pubkey, 1);
+		secp256k1_ec_pubkey_serialize(secp256k1_ctx, pub, &len, &pubkey, SECP256K1_EC_COMPRESSED);
 		assert(len == 33);
 
 		unsigned char tweak[32];

--- a/contracthashtool.c
+++ b/contracthashtool.c
@@ -292,7 +292,7 @@ int main(int argc, char* argv[]) {
 		else
 		    memcpy(data + 4 + sizeof(nonce), p2sh_bytes,     sizeof(p2sh_bytes));
 
-		size_t len = 0;
+		size_t len = 33;
 		if (secp256k1_ec_pubkey_create(secp256k1_ctx, &pubkey, priv) != 1)
 			ERROREXIT("Private key was invalid\n");
 		secp256k1_ec_pubkey_serialize(secp256k1_ctx, pub, &len, &pubkey, SECP256K1_EC_COMPRESSED);


### PR DESCRIPTION
Fixes wrt upstream changes at https://github.com/bitcoin/secp256k1/commit/9234391ed4d5fae38921a8bb4ca36f9f33736fd7

edit: fixed len arg
